### PR TITLE
WaitForSelectorOptions and WaitForFunctionOptions add new TimeoutReturnsNull option

### DIFF
--- a/lib/PuppeteerSharp.Tests/WaitTaskTests/FrameWaitForSelectorTests.cs
+++ b/lib/PuppeteerSharp.Tests/WaitTaskTests/FrameWaitForSelectorTests.cs
@@ -208,6 +208,15 @@ namespace PuppeteerSharp.Tests.WaitTaskTests
             Assert.Equal("waiting for function failed: timeout 10 ms exceeded", exception.Message);
         }
 
+        [PuppeteerTest("waittask.spec.ts", "Frame.waitForSelector", "should respect timeout")]
+        [PuppeteerFact]
+        public async Task ShouldRespectTimeoutReturnNull()
+        {
+            var result = await DevToolsContext.WaitForExpressionAsync("false", new WaitForFunctionOptions { Timeout = 10, TimeoutReturnsNull = true });
+
+            Assert.Null(result);
+        }
+
         [PuppeteerTest("waittask.spec.ts", "Frame.waitForSelector", "should have an error message specifically for awaiting an element to be hidden")]
         [PuppeteerFact]
         public async Task ShouldHaveAnErrorMessageSpecificallyForAwaitingAnElementToBeHidden()

--- a/lib/PuppeteerSharp/DOMWorld.cs
+++ b/lib/PuppeteerSharp/DOMWorld.cs
@@ -364,6 +364,7 @@ namespace CefSharp.Dom
                  options.Polling,
                  options.PollingInterval,
                  options.Timeout ?? _timeoutSettings.Timeout,
+                 options.TimeoutReturnsNull,
                  args);
 
             return await waitTask
@@ -380,7 +381,8 @@ namespace CefSharp.Dom
                 "function",
                 options.Polling,
                 options.PollingInterval,
-                options.Timeout ?? _timeoutSettings.Timeout);
+                options.Timeout ?? _timeoutSettings.Timeout,
+                options.TimeoutReturnsNull);
 
             return await waitTask
                 .Task
@@ -437,6 +439,7 @@ namespace CefSharp.Dom
                 polling,
                 null,
                 timeout,
+                options.TimeoutReturnsNull,
                 new object[] { selectorOrXPath, isXPath, options.Visible, options.Hidden });
 
             var handle = await waitTask.Task.ConfigureAwait(false);

--- a/lib/PuppeteerSharp/WaitForFunctionOptions.cs
+++ b/lib/PuppeteerSharp/WaitForFunctionOptions.cs
@@ -15,6 +15,12 @@ namespace CefSharp.Dom
         public int? Timeout { get; set; }
 
         /// <summary>
+        /// If set to <see langword="true" />, the method will return <see langword="null"/> if the timeout is reached.
+        /// The default (<see langword="false" />) will throw a <see cref="WaitTaskTimeoutException"/> if the timeout is reached."/>
+        /// </summary>
+        public bool TimeoutReturnsNull { get; set; } = false;
+
+        /// <summary>
         /// An interval at which the <c>pageFunction</c> is executed. defaults to <see cref="WaitForFunctionPollingOption.Raf"/>
         /// </summary>
         public WaitForFunctionPollingOption Polling { get; set; } = WaitForFunctionPollingOption.Raf;

--- a/lib/PuppeteerSharp/WaitForSelectorOptions.cs
+++ b/lib/PuppeteerSharp/WaitForSelectorOptions.cs
@@ -15,6 +15,12 @@ namespace CefSharp.Dom
         public int? Timeout { get; set; }
 
         /// <summary>
+        /// If set to <see langword="true" />, the method will return <see langword="null"/> if the timeout is reached.
+        /// The default (<see langword="false" />) will throw a <see cref="WaitTaskTimeoutException"/> if the timeout is reached."/>
+        /// </summary>
+        public bool TimeoutReturnsNull { get; set; } = false;
+
+        /// <summary>
         /// Wait for element to be present in DOM and to be visible.
         /// </summary>
         public bool Visible { get; set; }


### PR DESCRIPTION
- Instead of throwing exception on timeout, the task will return null